### PR TITLE
Support for PHP 7.4 weak references

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,19 @@
 language: php
 php:
-    - 7.1
-    - 7.2
-    - 7.3
+    - "7.1"
+    - "7.2"
+    - "7.3"
+    - "7.4snapshot"
 env:
-    - USE_WEAKREF=false
-    - USE_WEAKREF=true
+    - WITH_PECL_WEAKREF=false
+    - WITH_PECL_WEAKREF=true
 
 matrix:
-    allow_failures:
-        - php: 7.3
-          env: USE_WEAKREF=true
+    exclude:
+        - php: "7.3"
+          env: WITH_PECL_WEAKREF=true
+        - php: "7.4snapshot"
+          env: WITH_PECL_WEAKREF=true
 
 before-install:
     - composer self-update
@@ -18,4 +21,4 @@ before-install:
 # Create database, schema and fixtures
 install:
     - composer install
-    - if [ "$USE_WEAKREF" = "true" ]; then pecl install weakref-beta; fi
+    - if [ "$WITH_PECL_WEAKREF" = "true" ]; then pecl install weakref-beta; fi

--- a/src/Value/Ref/NativeWeakRef.php
+++ b/src/Value/Ref/NativeWeakRef.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace SolidPhp\ValueObjects\Value\Ref;
+
+use \WeakReference;
+
+/**
+ * Class NativeWeakRef
+ * A Ref implementation that uses PHP 7.4+ native WeakReference
+ * See https://wiki.php.net/rfc/weakrefs
+ *
+ * @internal
+ */
+class NativeWeakRef extends Ref
+{
+    /** @var WeakReference|null */
+    private $weakRef;
+
+    /**
+     * @return object|null
+     */
+    public function get()
+    {
+        return $this->weakRef ? $this->weakRef->get() : null;
+    }
+
+    /**
+     * @param object|null $object
+     */
+    public function set($object): void
+    {
+        $this->weakRef = WeakReference::create($object);
+    }
+
+    public function has(): bool
+    {
+        return (bool)$this->get();
+    }
+}

--- a/src/Value/Ref/PeclWeakRef.php
+++ b/src/Value/Ref/PeclWeakRef.php
@@ -6,9 +6,11 @@ use \WeakRef as PhpWeakRef;
 
 /**
  * Class WeakRef
+ * A Ref implementation that uses the PECL WeakRef extension (available in PHP < 7.3)
+ * See https://www.php.net/manual/en/book.weakref.php
  * @internal
  */
-class WeakRef extends Ref
+class PeclWeakRef extends Ref
 {
     /** @var PhpWeakRef|null */
     private $weakRef;

--- a/src/Value/Ref/Ref.php
+++ b/src/Value/Ref/Ref.php
@@ -2,11 +2,16 @@
 
 namespace SolidPhp\ValueObjects\Value\Ref;
 
-define('__SOLIDPHP_VALUEOBJECTS_WEAKREF_AVAILABLE', class_exists('\WeakRef'));
+define('__SOLIDPHP_VALUEOBJECTS_NATIVE_WEAKREF_AVAILABLE', class_exists('\WeakReference'));
+define('__SOLIDPHP_VALUEOBJECTS_PECL_WEAKREF_AVAILABLE', class_exists('\WeakRef'));
 
-if (__SOLIDPHP_VALUEOBJECTS_WEAKREF_AVAILABLE) {
+if (__SOLIDPHP_VALUEOBJECTS_NATIVE_WEAKREF_AVAILABLE) {
     function createRef(): Ref {
-        return new WeakRef();
+        return new NativeWeakRef();
+    }
+} elseif (__SOLIDPHP_VALUEOBJECTS_PECL_WEAKREF_AVAILABLE) {
+    function createRef(): Ref {
+        return new PeclWeakRef();
     }
 } else {
     function createRef(): Ref {

--- a/src/Value/SingleValueObjectTrait.php
+++ b/src/Value/SingleValueObjectTrait.php
@@ -22,6 +22,10 @@ trait SingleValueObjectTrait /* implements SingleValueObjectInterface */
         $this->value = $value;
     }
 
+    /**
+     * @param mixed $rawValue
+     * @return static
+     */
     final public static function of($rawValue): self
     {
         static::validateRawValue($rawValue);


### PR DESCRIPTION
Support for PHP 7.4 weak references [https://github.com/lhellemons/php-value-objects/issues/5]

- Added NativeWeakRef that works with PHP 7.4+ native WeakReference
  - Added feature detection to use it
- Added travis-ci config