### PR TITLE
fix problem with throwing WARNING on system without WeakRef class

### DIFF
--- a/src/Value/Ref/Ref.php
+++ b/src/Value/Ref/Ref.php
@@ -2,7 +2,7 @@
 
 namespace SolidPhp\ValueObjects\Value\Ref;
 
-define('__SOLIDPHP_VALUEOBJECTS_WEAKREF_AVAILABLE', class_exists('\WeakRef'));
+define('__SOLIDPHP_VALUEOBJECTS_WEAKREF_AVAILABLE', class_exists('\WeakRef',false));
 
 if (__SOLIDPHP_VALUEOBJECTS_WEAKREF_AVAILABLE) {
     function createRef(): Ref {


### PR DESCRIPTION
This line of code can cause optional WARNING because of autoload.